### PR TITLE
ciAnd7 catch startup connect

### DIFF
--- a/kurento-client/src/main/java/org/kurento/client/KurentoClient.java
+++ b/kurento-client/src/main/java/org/kurento/client/KurentoClient.java
@@ -63,7 +63,7 @@ public class KurentoClient {
 		try {
 			client.connect();
 		} catch (IOException e) {
-			throw new KurentoException("Exception connecting to KMS", e);
+		    log.warn("Exception connecting to KMS: {}", e.toString());
 		}
 	}
 

--- a/kurento-jsonrpc/kurento-jsonrpc-client/src/main/java/org/kurento/jsonrpc/client/JsonRpcClientWebSocket.java
+++ b/kurento-jsonrpc/kurento-jsonrpc-client/src/main/java/org/kurento/jsonrpc/client/JsonRpcClientWebSocket.java
@@ -221,7 +221,7 @@ public class JsonRpcClientWebSocket extends JsonRpcClient {
 				}
 
 				this.closeClient();
-				throw new KurentoException(label + " Timeout of "
+				throw new IOException(label + " Timeout of "
 						+ this.connectionTimeout
 						+ "ms when waiting to connect to Websocket server "
 						+ url);
@@ -232,7 +232,7 @@ public class JsonRpcClientWebSocket extends JsonRpcClient {
 				}
 
 				this.closeClient();
-				throw new KurentoException(label
+				throw new IOException(label
 						+ " Exception connecting to WebSocket server " + url, e);
 			}
 
@@ -243,7 +243,7 @@ public class JsonRpcClientWebSocket extends JsonRpcClient {
 						connectionListener.connectionFailed();
 					}
 					this.closeClient();
-					throw new KurentoException(label + " Timeout of "
+					throw new IOException(label + " Timeout of "
 							+ this.connectionTimeout
 							+ "ms when waiting to connect to Websocket server "
 							+ url);


### PR DESCRIPTION
Hi,
1.  Allow create KurentoClient without KMS connection. 
   Our application creates KurentoClient at startup and use it as singleton. KurentoClient try to connect to KMS in constructor. If KMS is not accessible at this moment, exception will be thrown. But actually, RcpClients supports reconnect so KMS, so KMS can be connected latter. Absents of KMS at the moment of creation KurentoClient it is not a reason to prevent application from starting.
2. To implement (1) we need to replace KurentoException by IOException at JsonRpcClientWebSocket.

Thanks.

  --
Andrey
