### PR TITLE
Fix error unflattening SystemInfo

### DIFF
--- a/kurento-client/src/main/java/org/kurento/client/internal/transport/serialization/ParamsFlattener.java
+++ b/kurento-client/src/main/java/org/kurento/client/internal/transport/serialization/ParamsFlattener.java
@@ -455,7 +455,7 @@ public class ParamsFlattener {
     int counter = 0;
     if (value != null) {
       for (Object object : value) {
-        list.add(unflattenValue(paramName + "[" + counter + "]", type, object, manager));
+        list.add(unflattenValue(paramName + "[" + counter + "]", object.getClass(), object, manager));
         counter++;
       }
     }


### PR DESCRIPTION
The old code generated an error when unflattening 

{capabilities=[transactions], __type__=ServerInfo, type=KMS, __module__=kurento, version=6.6.2~1.gd44e10d, modules=[{generationTime=Oct 31 2016 11:38:30, __type__=ModuleInfo, name=core, factories=[HubPort, MediaPipeline, PassThrough], __module__=kurento, version=6.6.2~4.g988f8fe}, {generationTime=Oct 31 2016 11:55:41, __type__=ModuleInfo, name=elements, factories=[AlphaBlending, Composite, Dispatcher, DispatcherOneToMany, HttpPostEndpoint, Mixer, PlayerEndpoint, RecorderEndpoint, RtpEndpoint, WebRtcEndpoint], __module__=kurento, version=6.6.2~2.g7595ce1}, {generationTime=Oct 31 2016 12:06:45, __type__=ModuleInfo, name=filters, factories=[FaceOverlayFilter, GStreamerFilter, ImageOverlayFilter, ZBarFilter], __module__=kurento, version=6.6.2~1.g8af2ae8}]}

The problem was that it was passing the type List when the type was really a String