### PR TITLE
Allow timeout on handshake handler

### DIFF
--- a/kurento-jsonrpc/kurento-jsonrpc-client/src/main/java/org/kurento/jsonrpc/client/JsonRpcClientNettyWebSocket.java
+++ b/kurento-jsonrpc/kurento-jsonrpc-client/src/main/java/org/kurento/jsonrpc/client/JsonRpcClientNettyWebSocket.java
@@ -251,7 +251,7 @@ public class JsonRpcClientNettyWebSocket extends AbstractJsonRpcClientWebSocket 
       while (channel == null || !channel.isOpen()) {
         try {
           channel = b.connect(host, port).sync().channel();
-          handler.handshakeFuture().sync();
+          if (!handler.handshakeFuture().await(this.connectionTimeout)) throw new WebSocketHandshakeException("Timeout");
         } catch (InterruptedException e) {
           // This should never happen
           log.warn("{} ERROR connecting WS Netty client, opening channel", label, e);

--- a/kurento-jsonrpc/kurento-jsonrpc-client/src/main/java/org/kurento/jsonrpc/client/JsonRpcClientNettyWebSocket.java
+++ b/kurento-jsonrpc/kurento-jsonrpc-client/src/main/java/org/kurento/jsonrpc/client/JsonRpcClientNettyWebSocket.java
@@ -250,7 +250,9 @@ public class JsonRpcClientNettyWebSocket extends AbstractJsonRpcClientWebSocket 
       final int maxRetries = 5;
       while (channel == null || !channel.isOpen()) {
         try {
-          channel = b.connect(host, port).sync().channel();
+          ChannelFuture connectFuture = b.connect(host, port);
+          if (!connectFuture.await(this.connectionTimeout)) throw new WebSocketHandshakeException("Timeout");
+          channel = connectFuture.channel();
           if (!handler.handshakeFuture().await(this.connectionTimeout)) throw new WebSocketHandshakeException("Timeout");
         } catch (InterruptedException e) {
           // This should never happen

--- a/kurento-jsonrpc/kurento-jsonrpc-client/src/main/java/org/kurento/jsonrpc/client/JsonRpcClientNettyWebSocket.java
+++ b/kurento-jsonrpc/kurento-jsonrpc-client/src/main/java/org/kurento/jsonrpc/client/JsonRpcClientNettyWebSocket.java
@@ -300,7 +300,7 @@ public class JsonRpcClientNettyWebSocket extends AbstractJsonRpcClientWebSocket 
     if (channel != null) {
       log.debug("{} Closing client", label);
       try {
-        channel.close().sync();
+        channel.close().await(this.connectionTimeout);
       } catch (Exception e) {
         log.debug("{} Could not properly close websocket client. Reason: {}", label, e.getMessage(),
             e);

--- a/kurento-jsonrpc/kurento-jsonrpc-server/src/main/java/org/kurento/jsonrpc/internal/ws/WebSocketServerSession.java
+++ b/kurento-jsonrpc/kurento-jsonrpc-server/src/main/java/org/kurento/jsonrpc/internal/ws/WebSocketServerSession.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.kurento.commons.PropertiesManager;
 import org.kurento.commons.exception.KurentoException;
+import org.kurento.commons.ThreadFactoryCreator;
 import org.kurento.jsonrpc.JsonRpcException;
 import org.kurento.jsonrpc.JsonUtils;
 import org.kurento.jsonrpc.TransportException;
@@ -56,7 +57,8 @@ public class WebSocketServerSession extends ServerSession {
 
   private final PendingRequests pendingRequests = new PendingRequests();
 
-  private ExecutorService execService = Executors.newCachedThreadPool();
+  private ExecutorService execService = Executors.newCachedThreadPool(
+      ThreadFactoryCreator.create("WebSocketServerSession-async"));
 
   public WebSocketServerSession(String sessionId, Object registerInfo,
       SessionsManager sessionsManager, WebSocketSession wsSession) {


### PR DESCRIPTION
Allow a timeout on the sync() call. This is to prevent the call from hanging and never returning.